### PR TITLE
Cristina first branch

### DIFF
--- a/jac2.cpp
+++ b/jac2.cpp
@@ -178,9 +178,9 @@ int main(int argc, char* argv[])
   int nbins_rap   = 25; 
   double rap_low  = 0.0;
   double rap_high = +2.5;
-  int nbins_pt    = 45; 
+  int nbins_pt    = 35; 
   double pt_low   = 25.;
-  double pt_high  = 70.;
+  double pt_high  = 60.;
 
   if(fit_qt_y){
     nbins_rap   = 13; 
@@ -323,10 +323,10 @@ int main(int argc, char* argv[])
   njacs += njacs_A4xy;
   
   auto toy_mass = [](double Q, double M, double G){
-    double gamma = TMath::Sqrt(M*M*(M*M+G*G));
-    double k = 2*TMath::Sqrt2()*M*G*gamma/TMath::Pi()/TMath::Sqrt(M*M+gamma);
-    return k/((Q*Q-M*M)*(Q*Q-M*M)+M*M*G*G);
-    //return 1./TMath::Pi()/(1 + (Q-M)*(Q-M)/G/G); // non-relativistic
+    //double gamma = TMath::Sqrt(M*M*(M*M+G*G));
+    //double k = 2*TMath::Sqrt2()*M*G*gamma/TMath::Pi()/TMath::Sqrt(M*M+gamma);
+    //return k/((Q*Q-M*M)*(Q*Q-M*M)+M*M*G*G);
+    return 1./TMath::Pi()/(1 + (Q-M)*(Q-M)/(G*G/4)); // non-relativistic
   };
 
   TF1* tf1toy_x = new TF1("toy_x", "[0]*x/TMath::Power(x*x+[1], 1.25)", 0.0, max_x);  
@@ -491,9 +491,9 @@ int main(int argc, char* argv[])
     double pt{0.0};
     double eta{0.0};
     while(!accept){
-      Q = TMath::Tan(rans[nslot]->Uniform(-TMath::Pi()*0.5, +TMath::Pi()*0.5))*GW + MW; 
+      Q = TMath::Tan(rans[nslot]->Uniform(-TMath::Pi()*0.5, +TMath::Pi()*0.5))*(GW/2) + MW; 
       while(Q < 50.0){
-	Q = TMath::Tan(rans[nslot]->Uniform(-TMath::Pi()*0.5, +TMath::Pi()*0.5))*GW + MW; 
+	Q = TMath::Tan(rans[nslot]->Uniform(-TMath::Pi()*0.5, +TMath::Pi()*0.5))*(GW/2) + MW; 
       }
       cos = rans[nslot]->Uniform(-1.0, 1.0);
       phi = rans[nslot]->Uniform(-TMath::Pi(), +TMath::Pi());
@@ -544,10 +544,10 @@ int main(int argc, char* argv[])
   dlast = std::make_unique<RNode>(dlast->Define("weights_mass", 
 						[&](double Q)->RVecD{
 						  RVecD out;
-						  double gamma = TMath::Sqrt(MW*MW*(MW*MW+GW*GW));
-                                                  double k = 2*TMath::Sqrt2()*MW*GW*gamma/TMath::Pi()/TMath::Sqrt(MW*MW+gamma);
-                                                  double gen = k/((Q*Q-MW*MW)*(Q*Q-MW*MW)+MW*MW*GW*GW);
-						  //double gen = 1./TMath::Pi()/(1 + (Q-MW)*(Q-MW)/GW/GW); // non-relativistic
+						  //double gamma = TMath::Sqrt(MW*MW*(MW*MW+GW*GW));
+                                                  //double k = 2*TMath::Sqrt2()*MW*GW*gamma/TMath::Pi()/TMath::Sqrt(MW*MW+gamma);
+                                                  //double gen = k/((Q*Q-MW*MW)*(Q*Q-MW*MW)+MW*MW*GW*GW);
+						  double gen = 1./TMath::Pi()/(1 + (Q-MW)*(Q-MW)/(GW/4)); // non-relativistic
 						  out.emplace_back( toy_mass(Q,MW,GW)/gen );
 						  out.emplace_back( toy_mass(Q,MW+MASSSHIFT,GW)/gen );
 						  out.emplace_back( toy_mass(Q,MW-MASSSHIFT,GW)/gen );
@@ -974,7 +974,7 @@ int main(int argc, char* argv[])
 
     dlast = std::make_unique<RNode>(dlast->Define("weight_jacM",[&](RVecD weights, double Q)->double {
       double w = weights.at(0);
-      w *= TMath::Pi()*toy_mass(Q,MW,GW)*2*(Q-MW)/GW/GW;
+      w *= TMath::Pi()*toy_mass(Q,MW,GW)*2*(Q-MW)/(GW*GW/4);
       return w;
     }, {(run=="full" ? "weights_cheb" : "weights_mctruth"), "Q"} ));
     

--- a/jac2.cpp
+++ b/jac2.cpp
@@ -28,8 +28,8 @@ using namespace boost::program_options;
 std::vector<std::string> helicities = {"A0", "A1", "A2", "A3", "A4"};
 
 constexpr double MW = 80.;
-constexpr double GW = 1.0;
-constexpr double MASSSHIFT = 0.050;
+constexpr double GW = 2.0; 
+constexpr double MASSSHIFT = 0.01; 
 constexpr int NMAX  = 200;
 //constexpr int NMASS = 20;
 constexpr int NMASS = 3;
@@ -323,7 +323,10 @@ int main(int argc, char* argv[])
   njacs += njacs_A4xy;
   
   auto toy_mass = [](double Q, double M, double G){
-    return 1./TMath::Pi()/(1 + (Q-M)*(Q-M)/G/G);
+    double gamma = TMath::Sqrt(M*M*(M*M+G*G));
+    double k = 2*TMath::Sqrt2()*M*G*gamma/TMath::Pi()/TMath::Sqrt(M*M+gamma);
+    return k/((Q*Q-M*M)*(Q*Q-M*M)+M*M*G*G);
+    //return 1./TMath::Pi()/(1 + (Q-M)*(Q-M)/G/G); // non-relativistic
   };
 
   TF1* tf1toy_x = new TF1("toy_x", "[0]*x/TMath::Power(x*x+[1], 1.25)", 0.0, max_x);  
@@ -541,7 +544,10 @@ int main(int argc, char* argv[])
   dlast = std::make_unique<RNode>(dlast->Define("weights_mass", 
 						[&](double Q)->RVecD{
 						  RVecD out;
-						  double gen = 1./TMath::Pi()/(1 + (Q-MW)*(Q-MW)/GW/GW);
+						  double gamma = TMath::Sqrt(MW*MW*(MW*MW+GW*GW));
+                                                  double k = 2*TMath::Sqrt2()*MW*GW*gamma/TMath::Pi()/TMath::Sqrt(MW*MW+gamma);
+                                                  double gen = k/((Q*Q-MW*MW)*(Q*Q-MW*MW)+MW*MW*GW*GW);
+						  //double gen = 1./TMath::Pi()/(1 + (Q-MW)*(Q-MW)/GW/GW); // non-relativistic
 						  out.emplace_back( toy_mass(Q,MW,GW)/gen );
 						  out.emplace_back( toy_mass(Q,MW+MASSSHIFT,GW)/gen );
 						  out.emplace_back( toy_mass(Q,MW-MASSSHIFT,GW)/gen );

--- a/run.py
+++ b/run.py
@@ -26,10 +26,10 @@ args = parser.parse_args()
 
 sample_sizes = {
     #'10M':     10000000,
-    #'100M':   100000000,
+    '100M':   100000000,
     #'1G':    1000000000,
     #'4G':    4000000000,
-    '10G':  10000000000,
+    #'10G':  10000000000,
     #'40G':  40000000000,
     ##'200G': 200000000000,
 }
@@ -78,7 +78,7 @@ fit_opts = {
 
 pol_default = {
     'run'    : "full",
-    'corr'   : [10,4],
+    'corr'   : [10,6],
     'A0'     : [3,2],
     'A1'     : [2,3],
     'A2'     : [3,2],
@@ -132,7 +132,7 @@ pol_syst['A2']   = [2,2]
 pol_syst['A2']   = [2,2]
 pol_syst['A3']   = [2,2]
 pol_syst['A4']   = [2,2]
-pol_systs.append( pol_syst )
+#pol_systs.append( pol_syst )
 
 pol_syst = copy.deepcopy(pol_default)
 pol_syst['run'] = "corr"
@@ -252,6 +252,7 @@ elif args.algo=='jac2_systs_vsN':
             if args.smear:
                 command += ' --smear'
             command += ' --max_y=3.5 --max_x=0.5'
+            command += ' --relativistic'
             print(command)
             if not args.dryrun:
                 os.system(command)   


### PR DESCRIPTION
- implemented the switch --relativistic to change the BW in toy_mass only
- the conversion factor is non-relativistic as it should be, correction made in the third commit
- the W width was set to 2 and the relevant formulae through the code changed to G/2
- still TODO change weight_jacM at line 979 with the relativistic version